### PR TITLE
Feature/hand assignment

### DIFF
--- a/src/main/java/com/Tbence132545/Melodigram/controller/ListWindowController.java
+++ b/src/main/java/com/Tbence132545/Melodigram/controller/ListWindowController.java
@@ -60,6 +60,10 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
     }
 
     @Override
+    public void onAssignHandsClicked(String midiFilename) {
+        //This is where I'll handle how the hand assignment window will look like.
+    }
+    @Override
     public void onWatchAndListenClicked(String midiFilename) {
         // Restore the crucial logic to handle the inconsistent path from the view
         String simpleFilename = midiFilename.replace("midi/", "");

--- a/src/main/java/com/Tbence132545/Melodigram/controller/ListWindowController.java
+++ b/src/main/java/com/Tbence132545/Melodigram/controller/ListWindowController.java
@@ -61,14 +61,12 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
 
     @Override
     public void onAssignHandsClicked(String midiFilename) {
-        // This is where we launch the PianoWindow in editing mode
-        // The logic is very similar to onWatchAndListenClicked
+        //Launch pianoWindow in editing mode
         String simpleFilename = midiFilename.replace("midi/", "");
         openPianoWindowForEditing(simpleFilename);
     }
     @Override
     public void onWatchAndListenClicked(String midiFilename) {
-        // Restore the crucial logic to handle the inconsistent path from the view
         String simpleFilename = midiFilename.replace("midi/", "");
         openPianoWindow(simpleFilename, false, null);
     }
@@ -90,8 +88,6 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
                 PianoWindow pianoWindow = new PianoWindow(range[0], range[1]);
                 PlaybackController playbackController = new PlaybackController(midiData.player(), pianoWindow);
 
-                // *** THE KEY STEP ***
-                // Put the application into hand assignment mode
                 playbackController.setEditingMode(true);
 
                 pianoWindow.setBackButtonListener(e -> {
@@ -113,7 +109,7 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
         SwingUtilities.invokeLater(() -> {
             MidiDevice inputDevice = null;
             try {
-                // Load MIDI data using the service - NO MORE DUPLICATION
+                // Load MIDI data using the service
                 MidiFileService.MidiData midiData = midiFileService.loadMidiData(midiFileName);
 
                 int[] range = MidiPlayer.extractNoteRange(midiData.sequence());

--- a/src/main/java/com/Tbence132545/Melodigram/controller/ListWindowController.java
+++ b/src/main/java/com/Tbence132545/Melodigram/controller/ListWindowController.java
@@ -70,14 +70,14 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
     public void onWatchAndListenClicked(String midiFilename) {
         // Restore the crucial logic to handle the inconsistent path from the view
         String simpleFilename = midiFilename.replace("midi/", "");
-        openPianoWindow(simpleFilename, false);
+        openPianoWindow(simpleFilename, false, null);
     }
 
     @Override
-    public void onPracticeClicked(String midiFilename) {
+    public void onPracticeClicked(String midiFilename, HandMode mode) {
         MidiInputSelector selector = new MidiInputSelector(view, deviceInfo -> {
             if (deviceInfo != null) {
-                openPianoWindow(midiFilename, true, deviceInfo);
+                openPianoWindow(midiFilename, true, mode, deviceInfo);
             }
         });
         selector.setVisible(true);
@@ -109,7 +109,7 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
             }
         });
     }
-    private void openPianoWindow(String midiFileName, boolean isPractice, MidiDevice.Info... midiDeviceInfo) {
+    private void openPianoWindow(String midiFileName, boolean isPractice, HandMode hand, MidiDevice.Info... midiDeviceInfo) {
         SwingUtilities.invokeLater(() -> {
             MidiDevice inputDevice = null;
             try {
@@ -123,7 +123,7 @@ public class ListWindowController implements ListWindow.MidiFileActionListener {
                 if (isPractice) {
                     if (midiDeviceInfo.length == 0) throw new IllegalStateException("MIDI device info required for practice mode.");
                     inputDevice = MidiSystem.getMidiDevice(midiDeviceInfo[0]);
-                    playbackController.setPracticeMode(true);
+                    playbackController.setPracticeMode(true, hand);
                     playbackController.setMidiInputDevice(inputDevice);
                 }
 

--- a/src/main/java/com/Tbence132545/Melodigram/controller/PlaybackController.java
+++ b/src/main/java/com/Tbence132545/Melodigram/controller/PlaybackController.java
@@ -1,5 +1,6 @@
 package com.Tbence132545.Melodigram.controller;
 
+import com.Tbence132545.Melodigram.model.MidiFileService;
 import com.Tbence132545.Melodigram.model.MidiPlayer;
 import com.Tbence132545.Melodigram.view.AnimationPanel;
 import com.Tbence132545.Melodigram.view.ListWindow;
@@ -307,7 +308,7 @@ public class PlaybackController {
         saveAssignments();
     }
 
-    // --- Private MIDI Callbacks and Helpers ---
+    //Private MIDI callbacks and helpers
     private static String computeSequenceHash(Sequence sequence) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
@@ -343,7 +344,6 @@ public class PlaybackController {
         return ASSIGNMENTS_DIR.resolve(hash + ".json");
     }
 
-    // --- REPLACED WITH GSON ---
     private void saveAssignments() {
         List<AnimationPanel.HandAssignment> items = animationPanel.getAssignedNotes();
         if (items.isEmpty()) {
@@ -382,13 +382,22 @@ public class PlaybackController {
             HandAssignmentFile data = gson.fromJson(content, HandAssignmentFile.class);
 
             if (data != null && data.assignments != null) {
-                // We could optionally verify the hash here:
-                // String currentHash = computeSequenceHash(sequence);
-                // if (currentHash.equals(data.midiHash)) { ... }
                 animationPanel.applyHandAssignments(data.assignments);
             }
         } catch (IOException e) {
-            e.printStackTrace(); // Non-fatal, just log
+            e.printStackTrace();
+        }
+    }
+    public static boolean assignmentFileExistsFor(String midiFileName) {
+        try {
+            MidiFileService service = new MidiFileService();
+            MidiFileService.MidiData midiData = service.loadMidiData(midiFileName);
+            String hash = computeSequenceHash(midiData.sequence());
+            Path path = ASSIGNMENTS_DIR.resolve(hash + ".json");
+            return Files.exists(path);
+        } catch (Exception e) {
+            e.printStackTrace(); // log for debugging
+            return false;
         }
     }
 
@@ -447,6 +456,7 @@ public class PlaybackController {
         }
         loadAssignmentsIfPresent(sequence);
     }
+
 
     //   Inner Class for MIDI Receiver
     private class MidiInputReceiver implements Receiver {

--- a/src/main/java/com/Tbence132545/Melodigram/controller/PlaybackController.java
+++ b/src/main/java/com/Tbence132545/Melodigram/controller/PlaybackController.java
@@ -3,6 +3,7 @@ package com.Tbence132545.Melodigram.controller;
 
 import com.Tbence132545.Melodigram.model.MidiPlayer;
 import com.Tbence132545.Melodigram.view.AnimationPanel;
+import com.Tbence132545.Melodigram.view.ListWindow;
 import com.Tbence132545.Melodigram.view.PianoWindow;
 import com.Tbence132545.Melodigram.view.SeekBar;
 
@@ -44,7 +45,7 @@ public class PlaybackController {
     private boolean isPracticeMode = false;
     private boolean isEditingMode= false;
     private boolean wasPlayingBeforeDrag = false;
-
+    private ListWindow.MidiFileActionListener.HandMode practiceHandMode = ListWindow.MidiFileActionListener.HandMode.BOTH;
     //   MIDI Input and Practice Mode State  
     private MidiDevice midiInputDevice;
     private final List<Integer> currentlyPressedNotes = new ArrayList<>();
@@ -176,7 +177,11 @@ public class PlaybackController {
         animationPanel.tick(delta);
         long nextTime = animationPanel.getCurrentTimeMillis();
 
-        List<Integer> onsets = animationPanel.getNotesStartingBetween((prevTime == 0) ? -1 : prevTime, nextTime);
+        List<Integer> onsets = animationPanel.getNotesStartingBetween(
+                (prevTime == 0) ? -1 : prevTime,
+                nextTime,
+                this.practiceHandMode // Pass the stored hand mode
+        );
 
         if (!onsets.isEmpty()) {
             awaitedNotes.clear();
@@ -289,14 +294,25 @@ public class PlaybackController {
             pianoWindow.repaint();
         }
     }
-    public void setPracticeMode(boolean enabled) {
+    public void setPracticeMode(boolean enabled, ListWindow.MidiFileActionListener.HandMode mode) {
         this.isPracticeMode = enabled;
+        this.practiceHandMode = mode; // Store the selected mode
+
+        // Pass the filter mode to the animation panel so it can hide notes
+        animationPanel.setPracticeFilterMode(mode);
+
         pianoWindow.disableButtons(enabled);
         if (enabled) {
             midiPlayer.stop();
             resetPracticeState();
         }
     }
+
+    // Add an overload for the old calls to not break anything
+    public void setPracticeMode(boolean enabled) {
+        setPracticeMode(enabled, ListWindow.MidiFileActionListener.HandMode.BOTH);
+    }
+
 
     public void setMidiInputDevice(MidiDevice device) {
         try {

--- a/src/main/java/com/Tbence132545/Melodigram/controller/PlaybackController.java
+++ b/src/main/java/com/Tbence132545/Melodigram/controller/PlaybackController.java
@@ -413,16 +413,28 @@ public class PlaybackController {
         }
     }
     private void onNoteOn(int midiNote) {
-
-        if (!isPracticeMode && !isEditingMode) {
-            SwingUtilities.invokeLater(() -> pianoWindow.highlightNote(midiNote));
+        if (isPracticeMode || isEditingMode) {
+            return;
         }
+
+        // --- THE ONLY CHANGE IS HERE ---
+
+        // 1. Get the player's precise current time.
+        long playerTimeMillis = midiPlayer.getSequencer().getMicrosecondPosition() / 1000;
+
+        // 2. Force the animation panel to sync to that exact time.
+        animationPanel.updatePlaybackTime(playerTimeMillis);
+
+        // Now, the existing code will work perfectly because the clocks are synced.
+        SwingUtilities.invokeLater(() -> pianoWindow.highlightNote(midiNote));
     }
 
     private void onNoteOff(int midiNote) {
-        if (!isPracticeMode && !isEditingMode) {
-            SwingUtilities.invokeLater(() -> pianoWindow.releaseNote(midiNote));
+        if (isPracticeMode || isEditingMode) {
+            return;
         }
+        // No changes needed here, as releasing the key doesn't require a color lookup.
+        SwingUtilities.invokeLater(() -> pianoWindow.releaseNote(midiNote));
     }
     private void resetPracticeState() {
         synchronized (currentlyPressedNotes) {

--- a/src/main/java/com/Tbence132545/Melodigram/model/MidiPlayer.java
+++ b/src/main/java/com/Tbence132545/Melodigram/model/MidiPlayer.java
@@ -101,25 +101,7 @@ public class MidiPlayer {
 
         return new int[]{lowest, highest};
     }
-    //method for skipping
-    public void forward() {
-        if (sequencer == null) return;
-        // 5 seconds = 5,000,000 microseconds
-        long jumpAmount = 5_000_000L;
-        long currentPosition = sequencer.getMicrosecondPosition();
-        sequencer.setMicrosecondPosition(currentPosition + jumpAmount);
-    }
 
-    //method for moving backwards
-    public void backward() {
-        if (sequencer == null) return;
-        // 5 seconds = 5,000,000 microseconds
-        long jumpAmount = 5_000_000L;
-        long currentPosition = sequencer.getMicrosecondPosition();
-        // Use Math.max to prevent setting a negative position
-        long newPosition = Math.max(0L, currentPosition - jumpAmount);
-        sequencer.setMicrosecondPosition(newPosition);
-    }
     //Starts the sequencer
     public void play() {
             sequencer.start();

--- a/src/main/java/com/Tbence132545/Melodigram/view/AnimationPanel.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/AnimationPanel.java
@@ -20,8 +20,11 @@ public class AnimationPanel extends JPanel {
     private static final Color COLOR_GRID_LINE = new Color(100, 100, 100, 150);
     private static final Color COLOR_BLACK_NOTE = new Color(255, 100, 100, 180);
     private static final Color COLOR_WHITE_NOTE = new Color(255, 215, 0, 180);
-    private static final Color COLOR_LEFT_HAND = new Color(30, 144, 255, 200);  // Dodger Blue
-    private static final Color COLOR_RIGHT_HAND = new Color(255, 69, 0, 200); // Orange Red
+    private static final Color COLOR_LEFT_WHITE = new Color(135, 206, 250, 220); // Light Sky Blue
+    private static final Color COLOR_LEFT_BLACK = new Color(25, 25, 112, 220);   // Midnight Blue
+    private static final Color COLOR_RIGHT_WHITE = new Color(250, 128, 114, 220); // Salmon
+    private static final Color COLOR_RIGHT_BLACK = new Color(178, 34, 34, 220);  // Firebrick
+
     private static final Font NOTE_TEXT_FONT = new Font("SansSerif", Font.BOLD, 16);
     private static final Color NOTE_TEXT_COLOR = Color.WHITE;
     // --- State ---
@@ -239,11 +242,20 @@ public class AnimationPanel extends JPanel {
 
             int topY = bottomY - noteHeight;
 
-            // NEW: Update the bounds rectangle on every draw call
             bounds.setBounds(keyInfo.x(), topY, keyInfo.width(), noteHeight);
 
             if (topY < panelHeight && bottomY > 0) {
-                // NEW: Choose color based on assigned hand
+
+                if (hand == Hands.LEFT) {
+                    g.setColor(isBlackKey ? COLOR_LEFT_BLACK : COLOR_LEFT_WHITE);
+                } else if (hand == Hands.RIGHT) {
+                    g.setColor(isBlackKey ? COLOR_RIGHT_BLACK : COLOR_RIGHT_WHITE);
+                } else {
+                    g.setColor(isBlackKey ? COLOR_BLACK_NOTE : COLOR_WHITE_NOTE);
+                }
+
+
+                g.fillRoundRect(bounds.x, bounds.y, bounds.width, noteHeight, NOTE_CORNER_RADIUS, NOTE_CORNER_RADIUS);
                 if(hand!=null){
                     String text = (hand == Hands.LEFT) ? "L": "R";
                     g.setFont(NOTE_TEXT_FONT);
@@ -255,14 +267,6 @@ public class AnimationPanel extends JPanel {
                     int textY = bounds.y + (bounds.height + textHeight) / 2;
                     g.drawString(text, textX, textY);
                 }
-                if (hand == Hands.LEFT) {
-                    g.setColor(COLOR_LEFT_HAND);
-                } else if (hand == Hands.RIGHT) {
-                    g.setColor(COLOR_RIGHT_HAND);
-                } else {
-                    g.setColor(isBlackKey ? COLOR_BLACK_NOTE : COLOR_WHITE_NOTE);
-                }
-                g.fillRoundRect(bounds.x, bounds.y, bounds.width, noteHeight, NOTE_CORNER_RADIUS, NOTE_CORNER_RADIUS);
             }
         }
 

--- a/src/main/java/com/Tbence132545/Melodigram/view/AnimationPanel.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/AnimationPanel.java
@@ -176,13 +176,7 @@ public class AnimationPanel extends JPanel {
         for (int i = notes.size() - 1; i >= 0; i--) {
             FallingNote n = notes.get(i);
             if (n.midiNote == midiNote && t >= n.noteOnTime && t < n.noteOffTime && n.hand != null) {
-
-                // --- THIS IS THE FIX ---
-
-                // 1. Get the original semi-transparent color.
                 Color semiTransparentColor = colorForHighlight(n);
-
-                // 2. Return a NEW, FULLY OPAQUE version of that color for the key.
                 return new Color(semiTransparentColor.getRed(), semiTransparentColor.getGreen(), semiTransparentColor.getBlue(), 255);
             }
         }
@@ -325,7 +319,7 @@ public class AnimationPanel extends JPanel {
 
 
                 g.fillRoundRect(bounds.x, bounds.y, bounds.width, noteHeight, NOTE_CORNER_RADIUS, NOTE_CORNER_RADIUS);
-                if(hand!=null){
+                if(hand!=null && isHandAssignmentEnabled){
                     String text = (hand == Hands.LEFT) ? "L": "R";
                     g.setFont(NOTE_TEXT_FONT);
                     g.setColor(NOTE_TEXT_COLOR);

--- a/src/main/java/com/Tbence132545/Melodigram/view/AnimationPanel.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/AnimationPanel.java
@@ -171,7 +171,31 @@ public class AnimationPanel extends JPanel {
     }
 
     // --- Inner Classes ---
+    public Color getAssignedHighlightColor(int midiNote) {
+        long t = getCurrentTimeMillis();
+        for (int i = notes.size() - 1; i >= 0; i--) {
+            FallingNote n = notes.get(i);
+            if (n.midiNote == midiNote && t >= n.noteOnTime && t < n.noteOffTime && n.hand != null) {
 
+                // --- THIS IS THE FIX ---
+
+                // 1. Get the original semi-transparent color.
+                Color semiTransparentColor = colorForHighlight(n);
+
+                // 2. Return a NEW, FULLY OPAQUE version of that color for the key.
+                return new Color(semiTransparentColor.getRed(), semiTransparentColor.getGreen(), semiTransparentColor.getBlue(), 255);
+            }
+        }
+        return null;
+    }
+
+    private Color colorForHighlight(FallingNote n) {
+        boolean isLeft = (n.hand == FallingNote.Hands.LEFT);
+        boolean isBlack = n.isBlackKey;
+        // Use the exact colors you use when drawing the falling notes
+        return isLeft ? (isBlack ? COLOR_LEFT_BLACK : COLOR_LEFT_WHITE)
+                : (isBlack ? COLOR_RIGHT_BLACK : COLOR_RIGHT_WHITE);
+    }
     private class NoteClickHandler extends MouseAdapter {
         @Override
         public void mousePressed(MouseEvent e) {

--- a/src/main/java/com/Tbence132545/Melodigram/view/ListWindow.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/ListWindow.java
@@ -8,6 +8,7 @@ public class ListWindow extends JFrame {
     public interface MidiFileActionListener {
         void onWatchAndListenClicked(String midiFilename);
         void onPracticeClicked(String midiFilename);
+        void onAssignHandsClicked(String midiFilename);
     }
     private final JPanel contentPanel;
     private JButton backButton;
@@ -157,8 +158,11 @@ public class ListWindow extends JFrame {
             JButton practiceButton = createModernButton("Practice");
             practiceButton.addActionListener(e -> listener.onPracticeClicked(title));
 
+            JButton assignHandsButton = createModernButton("Assign Hands");
+            assignHandsButton.addActionListener(e -> listener.onAssignHandsClicked(title));
             contentPanel.add(listenButton);
             contentPanel.add(practiceButton);
+            contentPanel.add(assignHandsButton);
             contentPanel.setVisible(false);
 
             titleButton.addActionListener(e -> toggleVisibility());

--- a/src/main/java/com/Tbence132545/Melodigram/view/ListWindow.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/ListWindow.java
@@ -1,18 +1,20 @@
 package com.Tbence132545.Melodigram.view;
 
+import com.Tbence132545.Melodigram.controller.PlaybackController;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
 
 public class ListWindow extends JFrame {
+
     public interface MidiFileActionListener {
-        enum HandMode {
-            LEFT, RIGHT, BOTH
-        }
+        enum HandMode { LEFT, RIGHT, BOTH }
         void onWatchAndListenClicked(String midiFilename);
         void onPracticeClicked(String midiFilename, HandMode mode);
         void onAssignHandsClicked(String midiFilename);
     }
+
     private final JPanel contentPanel;
     private JButton backButton;
     private JButton importButton;
@@ -22,13 +24,12 @@ public class ListWindow extends JFrame {
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         setExtendedState(JFrame.MAXIMIZED_BOTH);
 
-        // === Main container panel ===
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BorderLayout(20, 20));
+        // Main container
+        JPanel mainPanel = new JPanel(new BorderLayout(20, 20));
         mainPanel.setBorder(BorderFactory.createEmptyBorder(30, 30, 30, 30));
         mainPanel.setBackground(Color.BLACK);
 
-        // --- Top panel ---
+        // Top panel
         JPanel topPanel = new JPanel(new BorderLayout());
         topPanel.setBackground(Color.BLACK);
 
@@ -43,14 +44,12 @@ public class ListWindow extends JFrame {
 
         importButton = createModernButton("Import MIDI");
         backButton = createModernButton("<- Back to Main Menu");
-
         buttonPanel.add(importButton);
         buttonPanel.add(backButton);
-
         topPanel.add(buttonPanel, BorderLayout.EAST);
         mainPanel.add(topPanel, BorderLayout.NORTH);
 
-        // === Scrollable content ===
+        // Scrollable content
         contentPanel = new JPanel();
         contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
         contentPanel.setBackground(Color.BLACK);
@@ -69,12 +68,9 @@ public class ListWindow extends JFrame {
             protected void paintComponent(Graphics g) {
                 Graphics2D g2 = (Graphics2D) g.create();
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-                Color baseColor = new Color(200, 60, 60);  // red
-                Color hoverColor = new Color(170, 40, 40); // darker red
-                Color currentColor = getModel().isRollover() ? hoverColor : baseColor;
-
-                g2.setColor(currentColor);
+                Color baseColor = new Color(200, 60, 60);
+                Color hoverColor = new Color(170, 40, 40);
+                g2.setColor(getModel().isRollover() ? hoverColor : baseColor);
                 g2.fillRoundRect(0, 0, getWidth(), getHeight(), 15, 15);
 
                 g2.setColor(Color.WHITE);
@@ -82,7 +78,6 @@ public class ListWindow extends JFrame {
                 int textX = (getWidth() - fm.stringWidth(getText())) / 2;
                 int textY = (getHeight() + fm.getAscent() - fm.getDescent()) / 2;
                 g2.drawString(getText(), textX, textY);
-
                 g2.dispose();
             }
         };
@@ -120,17 +115,11 @@ public class ListWindow extends JFrame {
         contentPanel.repaint();
     }
 
-    // Collapsible Panel with theme
-    // java
-// In com.Tbence132545.Melodigram.view.ListWindow
-// REPLACE the entire CollapsiblePanel class with this new one
-
     private static class CollapsiblePanel extends JPanel {
         private final JButton titleButton;
-        private final JPanel cardsPanel; // This will hold our different views
+        private final JPanel cardsPanel;
         private final CardLayout cardLayout;
 
-        // Panel identifiers for CardLayout
         private static final String MAIN_ACTIONS = "MAIN_ACTIONS";
         private static final String PRACTICE_OPTIONS = "PRACTICE_OPTIONS";
 
@@ -139,9 +128,8 @@ public class ListWindow extends JFrame {
             setAlignmentX(Component.LEFT_ALIGNMENT);
             setBackground(Color.BLACK);
 
-            // --- Title Button (no changes here) ---
+            // Title button
             titleButton = new JButton(title);
-            // ... (all the existing titleButton styling is correct)
             titleButton.setHorizontalAlignment(SwingConstants.LEFT);
             titleButton.setFont(new Font("Segoe UI", Font.BOLD, 16));
             titleButton.setFocusPainted(false);
@@ -151,101 +139,85 @@ public class ListWindow extends JFrame {
             titleButton.setForeground(Color.WHITE);
             titleButton.setBorder(BorderFactory.createEmptyBorder(10, 15, 10, 15));
             titleButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
-
             titleButton.addMouseListener(new java.awt.event.MouseAdapter() {
                 @Override
-                public void mouseEntered(java.awt.event.MouseEvent evt) {
-                    titleButton.setBackground(new Color(200, 60, 60));
-                }
+                public void mouseEntered(java.awt.event.MouseEvent evt) { titleButton.setBackground(new Color(200, 60, 60)); }
                 @Override
-                public void mouseExited(java.awt.event.MouseEvent evt) {
-                    titleButton.setBackground(new Color(40, 40, 40));
-                }
+                public void mouseExited(java.awt.event.MouseEvent evt) { titleButton.setBackground(new Color(40, 40, 40)); }
             });
 
-            // --- CardLayout Panel Setup ---
+            // Card layout panel
             cardLayout = new CardLayout();
             cardsPanel = new JPanel(cardLayout);
             cardsPanel.setOpaque(false);
+            cardsPanel.setVisible(false); // start collapsed
 
-            // --- Card 1: Main Action Buttons ---
+            // Main actions
             JPanel mainActionsPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 10));
             mainActionsPanel.setOpaque(false);
 
-            JButton listenButton = createModernButton("Listen and watch");
-            listenButton.addActionListener(e -> listener.onWatchAndListenClicked("midi/" + title));
-
-            JButton practiceButton = createModernButton("Practice");
-            practiceButton.addActionListener(e -> {
-                cardLayout.show(cardsPanel, PRACTICE_OPTIONS);
-                updatePanelHeight(); // Resize the panel to fit the new buttons
-            });
-
-            JButton assignHandsButton = createModernButton("Assign Hands");
-            assignHandsButton.addActionListener(e -> listener.onAssignHandsClicked("midi/" + title));
+            JButton listenButton = createCardButton("Listen and watch", e -> listener.onWatchAndListenClicked("midi/" + title));
+            JButton practiceButton = createCardButton("Practice", null); // listener added below
+            JButton assignHandsButton = createCardButton("Assign Hands", e -> listener.onAssignHandsClicked("midi/" + title));
 
             mainActionsPanel.add(listenButton);
             mainActionsPanel.add(practiceButton);
             mainActionsPanel.add(assignHandsButton);
 
-            // --- Card 2: Practice Option Buttons ---
+            // Practice options (lazy)
             JPanel practiceOptionsPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 10));
             practiceOptionsPanel.setOpaque(false);
 
-            JButton practiceLeftButton = createModernButton("Just Left Hand");
-            practiceLeftButton.addActionListener(e -> listener.onPracticeClicked(title, MidiFileActionListener.HandMode.LEFT));
+            practiceButton.addActionListener(e -> {
+                // check for assignments lazily
+                boolean hasAssignments = PlaybackController.assignmentFileExistsFor(title);
+                if (hasAssignments) {
+                    JButton left = createCardButton("Just Left Hand", ev -> listener.onPracticeClicked(title, MidiFileActionListener.HandMode.LEFT));
+                    JButton right = createCardButton("Just Right Hand", ev -> listener.onPracticeClicked(title, MidiFileActionListener.HandMode.RIGHT));
+                    JButton both = createCardButton("Both Hands", ev -> listener.onPracticeClicked(title, MidiFileActionListener.HandMode.BOTH));
+                    JButton back = createCardButton("<- Back", ev -> {
+                        cardLayout.show(cardsPanel, MAIN_ACTIONS);
+                        updatePanelHeight();
+                    });
+                    practiceOptionsPanel.removeAll();
+                    practiceOptionsPanel.add(left);
+                    practiceOptionsPanel.add(right);
+                    practiceOptionsPanel.add(both);
+                    practiceOptionsPanel.add(back);
 
-            JButton practiceRightButton = createModernButton("Just Right Hand");
-            practiceRightButton.addActionListener(e -> listener.onPracticeClicked(title, MidiFileActionListener.HandMode.RIGHT));
-
-            JButton practiceBothButton = createModernButton("Both Hands");
-            practiceBothButton.addActionListener(e -> listener.onPracticeClicked( title, MidiFileActionListener.HandMode.BOTH));
-
-            JButton backButton = createModernButton("<- Back");
-            backButton.addActionListener(e -> {
-                cardLayout.show(cardsPanel, MAIN_ACTIONS);
-                updatePanelHeight(); // Resize the panel back
+                    cardsPanel.add(practiceOptionsPanel, PRACTICE_OPTIONS);
+                    cardLayout.show(cardsPanel, PRACTICE_OPTIONS);
+                } else {
+                    listener.onPracticeClicked(title, MidiFileActionListener.HandMode.BOTH);
+                }
+                updatePanelHeight();
             });
 
-            practiceOptionsPanel.add(practiceLeftButton);
-            practiceOptionsPanel.add(practiceRightButton);
-            practiceOptionsPanel.add(practiceBothButton);
-            practiceOptionsPanel.add(backButton);
-
-            // --- Final Assembly ---
+            // Add cards
             cardsPanel.add(mainActionsPanel, MAIN_ACTIONS);
-            cardsPanel.add(practiceOptionsPanel, PRACTICE_OPTIONS);
-            cardsPanel.setVisible(false);
 
+            // Toggle collapse
             titleButton.addActionListener(e -> toggleVisibility());
+
             add(titleButton, BorderLayout.NORTH);
             add(cardsPanel, BorderLayout.CENTER);
             updatePanelHeight();
         }
 
-        private JButton createModernButton(String text) {
-            // This helper method is perfect, no changes needed here.
+        private JButton createCardButton(String text, ActionListener listener) {
             JButton button = new JButton(text);
             button.setFocusPainted(false);
             button.setContentAreaFilled(false);
             button.setOpaque(true);
-            Color baseColor = new Color(180, 40, 40);
-            Color hoverColor = new Color(220, 60, 60);
-            button.setBackground(baseColor);
+            button.setBackground(new Color(180, 40, 40));
             button.setForeground(Color.WHITE);
             button.setFont(new Font("Segoe UI", Font.PLAIN, 14));
             button.setCursor(new Cursor(Cursor.HAND_CURSOR));
-            button.setAlignmentY(Component.CENTER_ALIGNMENT);
             button.setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 20));
+            if (listener != null) button.addActionListener(listener);
             button.addMouseListener(new java.awt.event.MouseAdapter() {
-                @Override
-                public void mouseEntered(java.awt.event.MouseEvent evt) {
-                    button.setBackground(hoverColor);
-                }
-                @Override
-                public void mouseExited(java.awt.event.MouseEvent evt) {
-                    button.setBackground(baseColor);
-                }
+                @Override public void mouseEntered(java.awt.event.MouseEvent evt) { button.setBackground(new Color(220, 60, 60)); }
+                @Override public void mouseExited(java.awt.event.MouseEvent evt) { button.setBackground(new Color(180, 40, 40)); }
             });
             return button;
         }
@@ -258,20 +230,10 @@ public class ListWindow extends JFrame {
         }
 
         private void updatePanelHeight() {
-            // This now needs to calculate height based on the currently visible card
-            JPanel visiblePanel = null;
-            for (Component comp : cardsPanel.getComponents()) {
-                if (comp.isVisible()) {
-                    visiblePanel = (JPanel) comp;
-                    break;
-                }
-            }
-
             int contentHeight = 0;
-            if (cardsPanel.isVisible() && visiblePanel != null) {
-                contentHeight = visiblePanel.getPreferredSize().height;
+            for (Component comp : cardsPanel.getComponents()) {
+                if (comp.isVisible()) contentHeight = comp.getPreferredSize().height;
             }
-
             int height = titleButton.getPreferredSize().height + contentHeight;
             setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
         }

--- a/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
@@ -362,8 +362,6 @@ public class PianoWindow extends JFrame {
         return keyButton;
     }
 
-    // java
-// Replace the entire setKeyColor method in com.Tbence132545.Melodigram.view.PianoWindow
 
     private void setKeyColor(int midiNote, boolean isHighlighted) {
         JButton key = noteToKeyButton.get(midiNote);
@@ -371,21 +369,20 @@ public class PianoWindow extends JFrame {
 
         KeyType keyType = KeyType.fromMidiNote(midiNote);
         if (isHighlighted) {
-            // --- THIS IS THE CORRECTED LOGIC ---
 
-            // 1. Ask the animation panel for the specific hand-assigned color.
+            //Ask the animation panel for the specific hand-assigned color.
             Color assignedColor = animationPanel.getAssignedHighlightColor(midiNote);
 
             if (assignedColor != null) {
-                // 2. If we found one, use it!
+                //If we found one, use it
                 key.setBackground(assignedColor);
             } else {
-                // 3. Otherwise, use the default highlight color as a fallback.
+                //Otherwise, use the default highlight color as a fallback.
                 key.setBackground(keyType == KeyType.WHITE ? COLOR_WHITE_KEY_HIGHLIGHT : COLOR_BLACK_KEY_HIGHLIGHT);
             }
 
         } else {
-            // This part is for releasing the key, it's correct.
+            // This part is for releasing the key
             key.setBackground(keyType == KeyType.WHITE ? Color.WHITE : Color.BLACK);
         }
         key.repaint();

--- a/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
@@ -362,14 +362,30 @@ public class PianoWindow extends JFrame {
         return keyButton;
     }
 
+    // java
+// Replace the entire setKeyColor method in com.Tbence132545.Melodigram.view.PianoWindow
+
     private void setKeyColor(int midiNote, boolean isHighlighted) {
         JButton key = noteToKeyButton.get(midiNote);
         if (key == null) return;
 
         KeyType keyType = KeyType.fromMidiNote(midiNote);
         if (isHighlighted) {
-            key.setBackground(keyType == KeyType.WHITE ? COLOR_WHITE_KEY_HIGHLIGHT : COLOR_BLACK_KEY_HIGHLIGHT);
+            // --- THIS IS THE CORRECTED LOGIC ---
+
+            // 1. Ask the animation panel for the specific hand-assigned color.
+            Color assignedColor = animationPanel.getAssignedHighlightColor(midiNote);
+
+            if (assignedColor != null) {
+                // 2. If we found one, use it!
+                key.setBackground(assignedColor);
+            } else {
+                // 3. Otherwise, use the default highlight color as a fallback.
+                key.setBackground(keyType == KeyType.WHITE ? COLOR_WHITE_KEY_HIGHLIGHT : COLOR_BLACK_KEY_HIGHLIGHT);
+            }
+
         } else {
+            // This part is for releasing the key, it's correct.
             key.setBackground(keyType == KeyType.WHITE ? Color.WHITE : Color.BLACK);
         }
         key.repaint();

--- a/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
@@ -36,6 +36,7 @@ public class PianoWindow extends JFrame {
     private final JButton backButton;
     private final JButton backwardButton;
     private final JButton forwardButton;
+    private final JButton saveButton;
     private SeekBar seekBar;
 
     // --- Piano State ---
@@ -57,7 +58,8 @@ public class PianoWindow extends JFrame {
         JPanel controlPanel = createControlPanel(this.playButton = new JButton("||"),
                 this.backButton = new JButton("←"),
                 this.backwardButton = new JButton("⏪"),
-                this.forwardButton = new JButton("⏩"));
+                this.forwardButton = new JButton("⏩"),
+                this.saveButton = new JButton("Save"));
 
         this.pianoPanel = createPianoPanel();
         this.animationPanel = new AnimationPanel(this::getKeyInfo, this.lowestNote, this.highestNote);
@@ -82,7 +84,8 @@ public class PianoWindow extends JFrame {
         getContentPane().setBackground(new Color(230, 230, 230));
     }
 
-    private JPanel createControlPanel(JButton play, JButton back, JButton backward, JButton forward) {
+    // Update the method signature to accept the new button
+    private JPanel createControlPanel(JButton play, JButton back, JButton backward, JButton forward, JButton save) {
         JPanel panel = new JPanel(new GridBagLayout());
         panel.setBackground(COLOR_CONTROL_PANEL_BG);
 
@@ -94,13 +97,22 @@ public class PianoWindow extends JFrame {
         styleControlButton(play, buttonSize, hoverEffect);
         styleControlButton(forward, buttonSize, hoverEffect);
 
+        // --- NEW: Style the save button and hide it by default ---
+        styleControlButton(save, new Dimension(80, 50), hoverEffect);
+        save.setVisible(false);
+        // ---
+
         GridBagConstraints gbc = new GridBagConstraints();
+
+        // Back Button (Far Left - gridx=0)
+        gbc.gridx = 0;
         gbc.gridheight = 2;
         gbc.anchor = GridBagConstraints.WEST;
         gbc.fill = GridBagConstraints.VERTICAL;
         gbc.insets = new Insets(5, 5, 5, 5);
         panel.add(back, gbc);
 
+        // Center Buttons Panel (Middle - gridx=1)
         JPanel centerButtonPanel = new JPanel(new GridBagLayout());
         centerButtonPanel.setOpaque(false);
         GridBagConstraints cbc = new GridBagConstraints();
@@ -111,10 +123,20 @@ public class PianoWindow extends JFrame {
 
         gbc = new GridBagConstraints();
         gbc.gridx = 1;
-        gbc.weightx = 1.0;
+        gbc.weightx = 1.0; // This makes the center panel stretch to fill space
         gbc.anchor = GridBagConstraints.CENTER;
         gbc.fill = GridBagConstraints.VERTICAL;
         panel.add(centerButtonPanel, gbc);
+
+        // --- NEW: Save Button (Far Right - gridx=2) ---
+        gbc = new GridBagConstraints();
+        gbc.gridx = 2; // Place it in the third column
+        gbc.gridheight = 2;
+        gbc.anchor = GridBagConstraints.EAST; // Pin it to the right side
+        gbc.fill = GridBagConstraints.VERTICAL;
+        gbc.insets = new Insets(5, 5, 5, 5);
+        panel.add(save, gbc);
+        // ---
 
         return panel;
     }
@@ -262,7 +284,9 @@ public class PianoWindow extends JFrame {
         // Add to the control panel, not the frame
         ((JPanel)getContentPane().getComponent(0)).add(seekBarComponent, gbc);
     }
-
+    public void setEditingMode(boolean isEditing){
+        saveButton.setVisible(isEditing);
+    }
     public void disableButtons(boolean shouldDisable) {
         playButton.setEnabled(!shouldDisable);
         backwardButton.setEnabled(!shouldDisable);
@@ -299,6 +323,7 @@ public class PianoWindow extends JFrame {
     public void setBackButtonListener(ActionListener listener) { backButton.addActionListener(listener); }
     public void setBackwardButtonListener(ActionListener listener) { backwardButton.addActionListener(listener); }
     public void setForwardButtonListener(ActionListener listener) { forwardButton.addActionListener(listener); }
+    public void setSaveButtonListener(ActionListener listener) { saveButton.addActionListener(listener); }
 
     // --- Private Helper Methods ---
 

--- a/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
+++ b/src/main/java/com/Tbence132545/Melodigram/view/PianoWindow.java
@@ -190,7 +190,7 @@ public class PianoWindow extends JFrame {
             JButton keyButton = createKeyButton(keyType);
 
             if (keyType == KeyType.WHITE) {
-                addWhiteKey(keyButton, whiteKeyIndex, i == middleCNote);
+                addWhiteKey(keyButton, whiteKeyIndex, i == middleCNote,i);
                 whiteKeyIndex++;
             } else {
                 addBlackKey(keyButton, whiteKeyIndex);
@@ -228,26 +228,24 @@ public class PianoWindow extends JFrame {
         return closestC;
     }
 
-    private void addWhiteKey(JButton keyButton, int whiteKeyIndex, boolean isMiddleC) {
+    private void addWhiteKey(JButton keyButton, int whiteKeyIndex, boolean isMiddleC, int midiNote) {
         keyButton.setBounds(whiteKeyIndex * whiteKeyWidth, 0, whiteKeyWidth, WHITE_KEY_HEIGHT);
+
         if (isMiddleC) {
-            int octave = (keyButton.hashCode() / 12) -1; // hashCode is midi note number, set in createKey
-            int noteNumber = noteToKeyButton.entrySet().stream()
-                    .filter(entry -> entry.getValue() == keyButton)
-                    .map(Map.Entry::getKey)
-                    .findFirst()
-                    .orElse(-1);
+            // We now have the correct midiNote, so we can calculate the octave directly.
+            int octave = (midiNote / 12) - 1;
+            JLabel label = new JLabel("C" + octave, SwingConstants.CENTER);
+            label.setFont(PIANO_LABEL_FONT);
 
-            if(noteNumber != -1) {
-                octave = (noteNumber / 12) -1;
-                JLabel label = new JLabel("C" + octave, SwingConstants.CENTER);
-                label.setFont(PIANO_LABEL_FONT);
-                label.setBounds(0, WHITE_KEY_HEIGHT - 20, whiteKeyWidth, 20);
-                keyButton.setLayout(new BorderLayout()); // Use layout manager for label
-                keyButton.add(label, BorderLayout.SOUTH);
-            }
+            // This prevents visual glitches when the key is highlighted.
+            label.setOpaque(false);
+            // A dark color will be visible on the white key.
+            label.setForeground(Color.DARK_GRAY);
 
+            keyButton.setLayout(new BorderLayout());
+            keyButton.add(label, BorderLayout.SOUTH);
         }
+
         pianoPanel.add(keyButton, JLayeredPane.DEFAULT_LAYER);
     }
 


### PR DESCRIPTION
Implemented hand assignment. 
Users are now given the option to "Assign hands" to midi files.
The "Assign hands" button opens a modified version of the visualization, letting the users right click and left click on the falling notes to mark them right handed and left handed respectively. Users can save the hand assignment. 
If a midi file has a hand assignment, users are prompted between choosing "Just left", "Just right" or "Both" upon pressing the practice button, to practice hands seperately or together. 
The hand assignment gives new colours to the falling notes, which (if the midi file has a hand assignment json) will show in Listen and watch as well. 
